### PR TITLE
Add embedded webview support in search URL input

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,8 @@ const createWindow = () => {
     visibleOnFullScreen: true,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
-      devTools: false
+      devTools: false,
+      webviewTag: true
     },
     show: false,
     // type: 'toolbar', // Commenting out to test visibility


### PR DESCRIPTION
## Summary
- enabled Electron `webviewTag` for the main window so in-app web content can be rendered
- added URL parsing helper in `Island.jsx` to distinguish direct URLs from search queries
- updated Search view behavior:
  - pressing Enter on a direct URL now opens it inside an embedded webview in the island
  - search queries still open externally in Google (existing behavior)
  - selecting a search result now opens it in the embedded webview
- added webview controls in Search view:
  - current URL label
  - **Open External** button
  - **Close** button
  - Escape closes the embedded webview first, then exits search view
- expanded search view dimensions when embedded webview is active for a usable browsing area

## Notes
- Build validation is currently blocked by missing `electron-forge` binary in this environment, and dependency install (`npm ci`) did not complete successfully due environment/package fetch constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ea2b07e883229e89658725480d6f)