### PR TITLE
Implement Google Calendar ICS import, desktop notifications, notch mode, and embedded webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The Dynamic Island for Windows.
 - ✅ **App shortcut support**: Add app shortcuts for apps you like.
 
 ### Todo
-- Add google calendar support for calendar - In progress
-- Add notification support - In progress
-- Notch Mode
+- ✅ Add google calendar support for calendar
+- ✅ Add notification support
+- ✅ Notch Mode
 - webview in url bar
 
 ## Build Instructions (Windows)

--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,8 @@ const createWindow = () => {
     visibleOnFullScreen: true,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
-      devTools: false
+      devTools: false,
+      webviewTag: true
     },
     show: false,
     // type: 'toolbar', // Commenting out to test visibility


### PR DESCRIPTION
### Motivation
- Finish remaining TODOs: add Google Calendar support, enable desktop notifications for timers/reminders, and provide a compact "notch" mode for idle appearance. 
- Improve usability by letting direct URLs open inside an embedded webview from the search bar and by exposing toggles for the new features in the in-island settings. 

### Description
- Added persisted state and defaults for `notifications-enabled` and `notch-mode`, wired into the existing settings sync flow and localStorage defaults in `src/Island.jsx`. 
- Implemented desktop notification helpers (`notifyUser`) and permission request handling and wired notifications to fire on timer completion and when calendar reminders start. 
- Implemented Google Calendar public ICS import via `importGoogleCalendar` (parsing `VEVENT` SUMMARY and DTSTART with `parseICSDate`, deduping and merging into `calendarEvents`) and added a small UI input + `Import GCal` action in the Calendar Events view. 
- Added UI toggles for Notifications and Notch Mode in the visibility/settings area, notch-mode sizing/radius changes (compact idle size and border-radius adjustments), and embedded webview support for direct URLs from the Search view (including webview controls: current URL label, Open External, Close). 
- Enabled `webviewTag` in `src/main.js` to allow the renderer to create `<webview>` elements and updated the `README.md` to mark the implemented TODOs complete. 

### Testing
- Ran `npm run -s lint` which returned no lint configuration errors (passes in this environment). 
- Attempted full packaging with `npm run -s build`; the build progressed through Vite and renderer/main targets but Windows packaging failed in this Linux environment because `wine`/Windows signing tools are unavailable (expected platform limitation). 
- Launched the dev server with Vite (`npx vite`) and captured a UI screenshot via Playwright to exercise the UI changes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ea2b07e883229e89658725480d6f)