### PR TITLE
Fix notch-mode corner flattening orientation

### DIFF
--- a/src/Island.jsx
+++ b/src/Island.jsx
@@ -1938,7 +1938,7 @@ export default function Island() {
             ? "#FFFFFF #808080 #808080 #FFFFFF"
             : "none",
         borderRadius: notchModeEnabled
-          ? (mode === 'large' ? '28px 28px 20px 20px' : mode === 'quick' ? '24px 24px 18px 18px' : '22px 22px 16px 16px')
+          ? (mode === 'large' ? '12px 12px 24px 24px' : mode === 'quick' ? '10px 10px 20px 20px' : '8px 8px 16px 16px')
           : (mode === "large" && theme === "win95"
             ? 0
             : (mode === "large" || mode === "quick")


### PR DESCRIPTION
### Motivation
- Fix visual geometry in `notch` mode where the bottom was flattened instead of the top, so the island looks like a top-attached notch across `still`, `quick`, and `large` modes.

### Description
- Adjusted the `borderRadius` tuple for `notchModeEnabled` in `src/Island.jsx` so `mode === 'large'` uses `"12px 12px 24px 24px"`, `quick` uses `"10px 10px 20px 20px"`, and the default uses `"8px 8px 16px 16px"` to make the top edge flatter and the bottom more rounded.

### Testing
- Ran `npm run build`, which reached packaging but failed in this Linux environment during Windows packaging because `wine` is not installed (build failure unrelated to the UI change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b04b9b6b88322ada98a192dd5ae09)