### PR TITLE
Improve home widget layout scaling and center third widget

### DIFF
--- a/src/Island.jsx
+++ b/src/Island.jsx
@@ -970,6 +970,18 @@ export default function Island() {
     }
   }, [mode]);
 
+  const safeHomeWidgets = enabledHomeWidgets.length > 0 ? enabledHomeWidgets : ['clock_media'];
+  const homeWidgetCount = safeHomeWidgets.length;
+  const widgetColumns = homeWidgetCount <= 1 ? 1 : 2;
+  const widgetRows = homeWidgetCount <= 2 ? 1 : 2;
+  const widgetGridTemplate = `repeat(${widgetRows}, minmax(0, 1fr)) / repeat(${widgetColumns}, minmax(0, 1fr))`;
+
+  const homeDimensions = (() => {
+    if (homeWidgetCount <= 1) return { width: 330, height: 250 };
+    if (homeWidgetCount === 2) return { width: 560, height: 250 };
+    return { width: 560, height: 290 };
+  })();
+
   // Dynamic Width/Height based on mode and view - INCREASED FOR AI/DROPBOX
   const { width, height } = (() => {
     if (showInIslandSettings && mode === 'large') {
@@ -991,7 +1003,7 @@ export default function Island() {
           if (embeddedWebUrl) return { width: 760, height: 540 };
           return { width: 420, height: searchResults.length > 0 ? (searchResults.length * 65 + 100) : 180 };
         case 'settings': return { width: 420, height: 380 };
-        case 'home': return { width: 560, height: 260 };
+        case 'home': return homeDimensions;
         default: return { width: 480, height: 240 };
       }
     }
@@ -1004,10 +1016,6 @@ export default function Island() {
     return { width: 155, height: 39 };
   })();
 
-  const safeHomeWidgets = enabledHomeWidgets.length > 0 ? enabledHomeWidgets : ['clock_media'];
-  const widgetColumns = safeHomeWidgets.length <= 1 ? 1 : 2;
-  const widgetRows = safeHomeWidgets.length <= 2 ? 1 : 2;
-  const widgetGridTemplate = `repeat(${widgetRows}, minmax(0, 1fr)) / repeat(${widgetColumns}, minmax(0, 1fr))`;
   // Remove obsolete Quick Apps state
 
 
@@ -3876,10 +3884,14 @@ export default function Island() {
             gridTemplate: widgetGridTemplate,
             gap: 10
           }}>
-            {safeHomeWidgets.map((widgetKey) => {
+            {safeHomeWidgets.map((widgetKey, widgetIndex) => {
               const todayEvents = Array.isArray(calendarEvents?.[getTodayIso()]) ? calendarEvents[getTodayIso()] : [];
               const nextTodo = todos.find((todo) => !todo.completed);
               const weatherStyle = getWeatherStyles();
+              const isCenteredThirdWidget = homeWidgetCount === 3 && widgetIndex === 2;
+              const widgetPositionStyle = isCenteredThirdWidget
+                ? { gridColumn: '1 / -1', justifySelf: 'center', width: 'calc(50% - 5px)' }
+                : undefined;
               const tileStyle = {
                 borderRadius: 24,
                 border: '1px solid rgba(255,255,255,0.07)',
@@ -3893,7 +3905,8 @@ export default function Island() {
                 minHeight: 0,
                 boxShadow: '0 10px 24px rgba(0,0,0,0.35)',
                 position: 'relative',
-                overflow: 'hidden'
+                overflow: 'hidden',
+                ...widgetPositionStyle
               };
 
               if (widgetKey === 'clock_media') {


### PR DESCRIPTION
### Motivation
- The home view scaled poorly when only 1–2 widgets were enabled and the 3-widget case did not center the third widget under the first two.
- Make the Island size and grid behavior adapt to the actual number of enabled home widgets for better visual balance.

### Description
- Centralized home widget sizing by introducing `homeWidgetCount` and `homeDimensions` and using them for the `home` branch of the size selection logic in `src/Island.jsx`.
- Compute `widgetGridTemplate` earlier from `homeWidgetCount` so grid definition matches the enabled widget count.
- Add layout tweak so when exactly 3 home widgets are enabled the third widget spans the full row and is centered via `{ gridColumn: '1 / -1', justifySelf: 'center', width: 'calc(50% - 5px)' }`.
- Kept the rest of the home widgets rendering logic intact and only extend `tileStyle` with the new positioning for the 3-widget case.

### Testing
- Ran `npm run lint` which completed successfully (project has no configured lint rules).
- Started a dev preview with `npx vite --host 0.0.0.0 --port 4173` to validate layout sizing in-browser and the server started successfully.
- Captured screenshots via a Playwright script to verify grid placement (screenshot capture succeeded, however the plain Vite browser preview is not a full Electron rendering so visual verification is limited).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b085674f08322b1bf5710cbd9a508)